### PR TITLE
Fix the cli argument name in the help text

### DIFF
--- a/bin/anti-trojan-source.js
+++ b/bin/anti-trojan-source.js
@@ -4,18 +4,17 @@ import meow from 'meow'
 import { globby } from 'globby'
 import { hasTrojanSource, hasTrojanSourceInFiles } from '../src/main.js'
 
-const cli = meow(
-  `
+const cli = meow(`
 	Usage
 	  $ anti-trojan-source <paths> <arguments>
 
 	Options
-    --help                  Show help
-    --filesPattern, -f      Return results as JSON
+	  --help                  Show help
+	  --files, -f             File pattern of files to check.
 
 	Examples
-	  $ anti-trojan-source --filesPattern='**/*.js'
-      $ anti-trojan-source /home/user/project/src/index.js /home/user/project/src/helper.js
+	  $ anti-trojan-source --files='**/*.js'
+	  $ anti-trojan-source /home/user/project/src/index.js /home/user/project/src/helper.js
 `,
   {
     importMeta: import.meta,


### PR DESCRIPTION
## Description

The help text was inconsistent with the actual code.
The formatting and indentation was also slightly inconsistent. I updated the formatting to be consistent with tabs and spaces per meow's [`readme.md`](https://github.com/sindresorhus/meow#usage)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #3

## Motivation and Context

The cli gives engineers running the tool with `--help` bad information, would love this tool to be helpful to all who would not lookup the docs or the sourcecode :)

## How Has This Been Tested?

Made the change. And ran:
*  `node bin\anti-trojan-source.js  --help `
* `yarn test`
* `yarn lint`
* `yarn build`
and all output looks good.

There was no coverage for --help so I didn't augment.

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/11037542/142566100-83c0b534-c2ef-4ede-b189-f8381a6af647.png)

After:
![image](https://user-images.githubusercontent.com/11037542/142566071-798b0c73-d4aa-4144-ac23-a0a60d90559b.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
    - Documentation was already using `--files` so code now matches docs, 
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
    ![image](https://user-images.githubusercontent.com/11037542/142566362-4c6e6f3c-b086-4c79-b8a8-bf70fa9b325c.png)
    CC0 Public Domain per [pxhere.com](https://pxhere.com/en/photo/1384579)
