### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://www.npmjs.org/package/anti-trojan-source"><img src="https://badgen.net/npm/v/anti-trojan-source" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/anti-trojan-source"><img src="https://badgen.net/npm/license/anti-trojan-source" alt="license"/></a>
   <a href="https://www.npmjs.org/package/anti-trojan-source"><img src="https://badgen.net/npm/dt/anti-trojan-source" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/anti-trojan-source/actions?workflow=CI"><img src="https://github.com/lirantal/anti-trojan-source/workflows/CI/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/anti-trojan-source/actions/workflows/main.yml"><img src="https://github.com/lirantal/anti-trojan-source/actions/workflows/main.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/anti-trojan-source"><img src="https://badgen.net/codecov/c/github/lirantal/anti-trojan-source" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.