### PR TITLE
feat: add explicit invisible blocklist and document scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,11 @@ This document is for human and automated agents working on the repository. It su
 `anti-trojan-source` is a security-focused npm package that scans text (source code, docs, configs) for **confusable and invisible Unicode** that can hide malicious logic or mislead reviewers. It targets:
 
 - **Trojan Source**-style attacks: bidirectional and format controls that change how text orders or displays without obvious visual cues in every context.
-- **Homoglyph / “glassworm”**-style tricks: dangerous characters from an explicit blocklist.
+- **Homoglyph / “glassworm”**-style tricks: dangerous characters from an explicit blocklist (not a full homoglyph / confusables database).
 - **Broad category coverage**: all characters classified as Unicode **Format (Cf)** and **Control (Cc)** (with a small whitelist for TAB, LF, CR), so new code points in those categories are caught without updating a hand-maintained list for every Unicode release.
+- **Strict supplemental blocklist**: a tiny set of **non-Cf/Cc** code points that are commonly invisible in UI fonts but still carry scalar values in source (e.g. certain Hangul fillers and U+034F); see [`README.md` § Scope](README.md#scope).
 
-Out of scope for this library: full natural-language or rendering-stack modeling, locale-specific normalization policies, and non-Unicode obfuscation.
+**What is in or out of scope** (threat model, UTF‑8 layers, homoglyphs, etc.) is maintained in the **[`README.md` Scope section](README.md#scope)** so it stays a single source of truth—update that table when the product boundary changes.
 
 ## Repository layout
 
@@ -52,7 +53,8 @@ Deprecated but still exported for downstream compatibility (prefer migrating cal
 
 ## Changing behavior
 
-- **New explicit characters**: update [`src/constants.js`](src/constants.js) if they are not already covered by Cf/Cc logic and you need them named or prioritized distinctly.
+- **New explicit characters**: update [`src/constants.js`](src/constants.js) if they are not already covered by Cf/Cc logic and you need them named or prioritized distinctly. Reserve this for **high-signal** scalars; document additions in [`README.md` Scope](README.md#scope).
+- **Strict supplemental invisibles** (non-Cf/Cc): keep the list **minimal** — prefer Cf/Cc coverage when Unicode classifies the code point that way.
 - **New Cf/Cc ranges** (Unicode adds blocks): update [`src/unicode-categories.js`](src/unicode-categories.js).
 - **Scanning logic**: only [`src/main.js`](src/main.js) unless you intentionally extend helpers elsewhere.
 

--- a/README.md
+++ b/README.md
@@ -33,23 +33,50 @@ If you're using ESLint:
 
 `anti-trojan-source` provides comprehensive protection by detecting:
 
-- **277 explicit confusable characters** including bidirectional Unicode, zero-width characters, variation selectors, and more
-- **All Unicode Format characters (Cf category)** - catches invisible formatting characters by category
-- **All Unicode Control characters (Cc category)** - except commonly-used whitespace (TAB, LF, CR)
-- **Extended Variation Selectors** (U+E0100 to U+E01EF) - 240 additional characters
+- **281 explicit confusable scalars** — bidirectional controls, zero-width characters, BMP variation selectors, a small set of non-Cf/Cc invisibles (Hangul fillers, U+034F), plus **240** supplementary variation selectors (U+E0100–U+E01EF)
+- **All Unicode Format characters (Cf category)** — invisible formatting characters by category (including Unicode **tag letters** used for ASCII smuggling / hidden payloads)
+- **All Unicode Control characters (Cc category)** — except commonly-used whitespace (TAB, LF, CR)
 
-This category-based approach makes the detection **future-proof** against new Unicode characters that may be added to dangerous categories.
+Category-based Cf/Cc detection keeps the tool **future-proof** as Unicode adds new format or control code points. The explicit list covers characters that matter for security but are **not** Cf/Cc (e.g. BMP variation selectors are **Mn**, not Cf).
+
+## Scope
+
+This project scans **decoded Unicode text** — the string you get after reading a UTF‑8 (or other Unicode encoding) file the usual way. It does **not** inspect raw bytes, URLs, or tokenizer-specific behavior.
+
+### In scope
+
+| Topic | Detection approach |
+| ----- | ------------------ |
+| Trojan Source (bidi embeddings, overrides, isolates, PDF, etc.) | Cf ranges + explicit list |
+| Zero-width / word joiner / BOM / soft hyphen (where Cf or listed) | Cf + explicit list |
+| **Unicode Tags block** (U+E0001, U+E0020–U+E007F) — invisible ASCII-shaped payloads ([background](https://embracethered.com/blog/posts/2024/hiding-and-finding-text-with-unicode-tags/)) | Cf |
+| Variation selectors (BMP U+FE00–U+FE0F + supplement U+E0100–U+E01EF) | Explicit list (**Mn** in Unicode, not Cf) |
+| **Strict explicit blocklist** of a few **non-Cf/Cc** scalars that often render invisibly (U+034F, U+115F, U+1160, U+3164) | Explicit list only |
+| Any other **Format (Cf)** or **Control (Cc)** code point | Category tables (Cc minus TAB/LF/CR) |
+| Dangerous confusables on the maintained explicit list (e.g. NO-BREAK SPACE) | Explicit list |
+
+### Out of scope
+
+| Topic | Reason |
+| ----- | ------ |
+| Full homoglyph / mixed-script confusable-IDN databases (“every Cyrillic lookalike of Latin”) | Requires a large, policy-heavy confusables data set; we only flag **listed** confusables plus **all** Cf/Cc |
+| UTF‑8 “sneaky” byte patterns, overlong encodings, non-Unicode steganography | Needs **byte-level** analysis, not scalar-by-scalar Unicode |
+| URL / percent-encoded layers, HTML entities | Decode/normalize elsewhere first |
+| Full rendering, grapheme clusters, locale-specific display rules | Tooling is scalar-based and intentionally simple |
+| Whether a finding is malicious | High-signal alert for human review |
 
 ## Invisible Characters Support Matrix
 
-The following table lists the various types of invisible character format that may be used in malicious attacks that `anti-trojan-source` is capable of detecting:
+The following table summarizes attack styles versus what this tool flags:
 
-| Attack Type                      | Supported | Description                                                                                                                                                                 |
-| -------------------------------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Trojan Source**                |     ✅    | Using bidirectional Unicode characters to create code that appears different from what the compiler executes. More details at [trojansource.codes](https://trojansource.codes). |
-| **Glassworm**                    |     ✅    | Using confusable characters (homoglyphs) to create misleading identifiers or string literals, which can lead to vulnerabilities.                                               |
-| **Extended Variation Selectors** |     ✅    | 240 additional variation selectors (U+E0100-U+E01EF) that can alter character appearance invisibly.                                                                           |
-| **Category-Based Detection**     |     ✅    | Detects ALL Unicode Format (Cf) and Control (Cc) characters by category, making detection future-proof.                                                                       |
+| Attack Type | Supported | Notes |
+| ----------- | :-------: | ----- |
+| **Trojan Source** | ✅ | Bidi / format controls per [trojansource.codes](https://trojansource.codes). |
+| **Glassworm / confusable identifiers** | ✅ (partial) | Flags **explicit** confusables and **all** Cf/Cc — not a complete homoglyph alphabet. |
+| **Unicode tag / “ASCII smuggling”** | ✅ | Tag letters are **Cf**; see [Embrace The Red](https://embracethered.com/blog/posts/2024/hiding-and-finding-text-with-unicode-tags/). |
+| **Extended variation selectors** | ✅ | U+E0100–U+E01EF on explicit list. |
+| **Category-based Cf / Cc** | ✅ | Future-proof for new format/control code points. |
+| **Invisible letters (strict list)** | ✅ | U+034F, Hangul fillers — explicit blocklist only. |
 
 ## Why is Confusable Unicode Character detection important?
 
@@ -63,6 +90,7 @@ Table of Contents
 
 - [About](#about)
   - [Detection Capabilities](#detection-capabilities)
+  - [Scope](#scope)
   - [Invisible Characters Support Matrix](#invisible-characters-support-matrix)
   - [Why is Confusable Unicode Character detection important?](#why-is-confusable-unicode-character-detection-important)
 - [Use as a CLI](#use-as-a-cli)
@@ -76,6 +104,7 @@ Table of Contents
   - [Simple boolean check](#simple-boolean-check)
   - [Detailed findings](#detailed-findings)
 - [Use as a pre-commit hook](#use-as-a-pre-commit-hook)
+- [References](#references)
 - [Contributing](#contributing)
 - [Author](#author)
 
@@ -268,6 +297,12 @@ repos:
     hooks:
       - id: anti-trojan-source
 ```
+
+# References
+
+- [Hiding and finding text with Unicode Tags](https://embracethered.com/blog/posts/2024/hiding-and-finding-text-with-unicode-tags/) — Unicode tag letters, LLM / review bypass, and links to specs (Embrace The Red).
+- [ASCII Smuggler](https://embracethered.com/blog/ascii-smuggler.html) — encode/decode tool for tags, variant selectors, and related invisible patterns (Embrace The Red).
+- [Trojan Source](https://trojansource.codes/) — original bidi / trojan source research and paper.
 
 # Contributing
 

--- a/__tests__/category-detection.test.js
+++ b/__tests__/category-detection.test.js
@@ -72,6 +72,10 @@ describe('Unicode Category Detection', () => {
     expect(getCharacterName(0x00a0)).toBe('NO-BREAK SPACE')
     expect(getCharacterName(0xfe00)).toBe('VARIATION SELECTOR-1')
     expect(getCharacterName(0xe0100)).toBe('VARIATION SELECTOR-17')
+    expect(getCharacterName(0x034f)).toBe('COMBINING GRAPHEME JOINER')
+    expect(getCharacterName(0x115f)).toBe('HANGUL CHOSEONG FILLER')
+    expect(getCharacterName(0x1160)).toBe('HANGUL JUNGSEONG FILLER')
+    expect(getCharacterName(0x3164)).toBe('HANGUL FILLER')
   })
 
   test('returns descriptive names for control characters', () => {

--- a/__tests__/glassworm-detection.test.js
+++ b/__tests__/glassworm-detection.test.js
@@ -41,8 +41,8 @@ test('detects NO-BREAK SPACE in fixture file', () => {
 })
 
 test('the list should include Extended Variation Selectors', () => {
-  // Should have 37 explicit chars + 240 Extended Variation Selectors = 277
-  expect(confusableChars.length).toBe(277)
+  // 41 explicit BMP scalars + 240 Extended Variation Selectors = 281
+  expect(confusableChars.length).toBe(281)
 })
 
 test('detects Extended Variation Selectors (U+E0100)', () => {
@@ -66,4 +66,28 @@ test('detects Extended Variation Selectors in middle of range', () => {
 test('detects Extended Variation Selectors in fixture file', () => {
   const fileContent = readFileSync('./__tests__/__fixtures__/true-extended-vs.js', 'utf-8')
   expect(hasConfusables({ sourceText: fileContent })).toBe(true)
+})
+
+test('detects COMBINING GRAPHEME JOINER (U+034F)', () => {
+  expect(hasConfusables({ sourceText: `a${String.fromCodePoint(0x034f)}b` })).toBe(true)
+})
+
+test('detects Hangul filler code points used as invisible smuggling', () => {
+  expect(hasConfusables({ sourceText: `x${String.fromCodePoint(0x115f)}y` })).toBe(true)
+  expect(hasConfusables({ sourceText: `x${String.fromCodePoint(0x1160)}y` })).toBe(true)
+  expect(hasConfusables({ sourceText: `x${String.fromCodePoint(0x3164)}y` })).toBe(true)
+})
+
+test('detailed mode names invisible letter blocklist characters', () => {
+  const findings = hasConfusables({
+    sourceText: `\u034f\u115f\u1160\u3164`,
+    detailed: true
+  })
+  expect(findings.map((f) => f.name)).toEqual([
+    'COMBINING GRAPHEME JOINER',
+    'HANGUL CHOSEONG FILLER',
+    'HANGUL JUNGSEONG FILLER',
+    'HANGUL FILLER'
+  ])
+  findings.forEach((f) => expect(f.category).toBe('Confusable'))
 })

--- a/cjs/constants.cjs
+++ b/cjs/constants.cjs
@@ -40,7 +40,13 @@ const explicitConfusableChars = [
   '\uFE0E', // VARIATION SELECTOR-15
   '\uFE0F', // VARIATION SELECTOR-16
   '\uFEFF', // ZERO WIDTH NO-BREAK SPACE (BOM)
-  '\u180E' // MONGOLIAN VOWEL SEPARATOR
+  '\u180E', // MONGOLIAN VOWEL SEPARATOR
+  // Non-Cf/Cc characters that are often invisible in UI fonts; used for the same
+  // “hidden payload” goals as zero-width / tag smuggling (strict explicit list only).
+  '\u034F', // COMBINING GRAPHEME JOINER (Mn)
+  '\u115F', // HANGUL CHOSEONG FILLER (Lo)
+  '\u1160', // HANGUL JUNGSEONG FILLER (Lo)
+  '\u3164' // HANGUL FILLER (Lo)
 ];
 
 // Generate Extended Variation Selectors (U+E0100 to U+E01EF)

--- a/cjs/unicode-categories.cjs
+++ b/cjs/unicode-categories.cjs
@@ -120,7 +120,11 @@ function getCategoryName(char) {
 function getCharacterName(codePoint) {
   const names = new Map([
     [0x00ad, 'SOFT HYPHEN'],
+    [0x034f, 'COMBINING GRAPHEME JOINER'],
     [0x061c, 'ARABIC LETTER MARK'],
+    [0x115f, 'HANGUL CHOSEONG FILLER'],
+    [0x1160, 'HANGUL JUNGSEONG FILLER'],
+    [0x3164, 'HANGUL FILLER'],
     [0x180e, 'MONGOLIAN VOWEL SEPARATOR'],
     [0x200b, 'ZERO WIDTH SPACE'],
     [0x200c, 'ZERO WIDTH NON-JOINER'],

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,7 +36,13 @@ const explicitConfusableChars = [
   '\uFE0E', // VARIATION SELECTOR-15
   '\uFE0F', // VARIATION SELECTOR-16
   '\uFEFF', // ZERO WIDTH NO-BREAK SPACE (BOM)
-  '\u180E' // MONGOLIAN VOWEL SEPARATOR
+  '\u180E', // MONGOLIAN VOWEL SEPARATOR
+  // Non-Cf/Cc characters that are often invisible in UI fonts; used for the same
+  // “hidden payload” goals as zero-width / tag smuggling (strict explicit list only).
+  '\u034F', // COMBINING GRAPHEME JOINER (Mn)
+  '\u115F', // HANGUL CHOSEONG FILLER (Lo)
+  '\u1160', // HANGUL JUNGSEONG FILLER (Lo)
+  '\u3164' // HANGUL FILLER (Lo)
 ]
 
 // Generate Extended Variation Selectors (U+E0100 to U+E01EF)

--- a/src/unicode-categories.js
+++ b/src/unicode-categories.js
@@ -116,7 +116,11 @@ export function getCategoryName(char) {
 export function getCharacterName(codePoint) {
   const names = new Map([
     [0x00ad, 'SOFT HYPHEN'],
+    [0x034f, 'COMBINING GRAPHEME JOINER'],
     [0x061c, 'ARABIC LETTER MARK'],
+    [0x115f, 'HANGUL CHOSEONG FILLER'],
+    [0x1160, 'HANGUL JUNGSEONG FILLER'],
+    [0x3164, 'HANGUL FILLER'],
     [0x180e, 'MONGOLIAN VOWEL SEPARATOR'],
     [0x200b, 'ZERO WIDTH SPACE'],
     [0x200c, 'ZERO WIDTH NON-JOINER'],


### PR DESCRIPTION

## Description

Add U+034F and Hangul filler code points to the confusable list with README scope tables and AGENTS pointers. Update tests and built cjs output.


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
