### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,35 @@
-# Agent specification: anti-trojan-source
+# AGENTS.md
 
-This document is for human and automated agents working on the repository. It summarizes purpose, architecture, public surfaces, and invariants so changes stay consistent and safe.
+Guidance for AI coding agents working in this repository.
 
-## Mission
+## Start Here
 
-`anti-trojan-source` is a security-focused npm package that scans text (source code, docs, configs) for **confusable and invisible Unicode** that can hide malicious logic or mislead reviewers. It targets:
+Before making changes, read:
 
-- **Trojan Source**-style attacks: bidirectional and format controls that change how text orders or displays without obvious visual cues in every context.
-- **Homoglyph / “glassworm”**-style tricks: dangerous characters from an explicit blocklist (not a full homoglyph / confusables database).
-- **Broad category coverage**: all characters classified as Unicode **Format (Cf)** and **Control (Cc)** (with a small whitelist for TAB, LF, CR), so new code points in those categories are caught without updating a hand-maintained list for every Unicode release.
-- **Strict supplemental blocklist**: a tiny set of **non-Cf/Cc** code points that are commonly invisible in UI fonts but still carry scalar values in source (e.g. certain Hangul fillers and U+034F); see [`README.md` § Scope](README.md#scope).
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
 
-**What is in or out of scope** (threat model, UTF‑8 layers, homoglyphs, etc.) is maintained in the **[`README.md` Scope section](README.md#scope)** so it stays a single source of truth—update that table when the product boundary changes.
+Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
 
-## Repository layout
+## Documentation
 
-| Area | Role |
-|------|------|
-| [`src/main.js`](src/main.js) | Core API: `hasConfusables`, `hasConfusablesInFiles`; composes explicit list + category checks. |
-| [`src/constants.js`](src/constants.js) | Explicit `confusableChars` (BMP bidi/zero-width/etc. + generated extended variation selectors U+10000 block). |
-| [`src/extended-blocklist.js`](src/extended-blocklist.js) | Opt-in homoglyphs / extra invisibles; only scanned when `extended: true` (CLI `--extended` / `--all`). |
-| [`src/unicode-categories.js`](src/unicode-categories.js) | Cf/Cc range tables, `isSuspiciousByCategory`, naming helpers for reporting. |
-| [`src/formatter.js`](src/formatter.js) | CLI output formatting (minimal, verbose, JSON-oriented messaging). |
-| [`bin/anti-trojan-source.js`](bin/anti-trojan-source.js) | CLI entry: globbing, stdin, delegates to library with `detailed: true` for reporting. |
-| [`cjs/`](cjs/) | **Generated** CommonJS output from Rollup. Do not edit by hand; run `npm run build` after changing `src/`. |
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
 
-Human-oriented background: [`docs/project.md`](docs/project.md), [`docs/design.md`](docs/design.md). Contribution norms: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+## PRs and Issues
 
-## Public API (library)
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
 
-- **`hasConfusables({ sourceText, detailed, extended })`**
-  - `detailed` false (default): returns `boolean`.
-  - `detailed` true: returns an array of findings: `line`, `column`, `codePoint`, `name`, `category`, **`severity`** (`high` | `low`), `snippet`.
-  - `extended` false (default): only core scan (Cf/Cc + `confusableChars`). `extended` true: also match [`extended-blocklist.js`](src/extended-blocklist.js) (low severity).
-- **`hasConfusablesInFiles({ filePaths, detailed, extended })`**: returns an array of `{ file, findings? }` for files that contain confusables (findings present when `detailed` is true).
-- Also exported: **`extendedConfusableChars`** (opt-in list array).
+## Releases
 
-Deprecated but still exported for downstream compatibility (prefer migrating callers):
-
-- `hasTrojanSource` → alias of `hasConfusables`
-- `hasTrojanSourceInFiles` → alias of `hasConfusablesInFiles`
-
-## CLI
-
-- Paths or `--files` / `-f` glob patterns.
-- `--verbose` / `-v`: per-finding detail (includes **high** / **low** and bidi **critical** labels).
-- `--json` / `-j`: machine-readable output (each finding includes `severity`).
-- `--extended` / `--all`: enable extended blocklist (low severity); see [README](README.md#extended-scan---extended--all).
-
-## Detection model (invariants)
-
-1. **Core layers** (always): (a) substring / membership against `confusableChars`; (b) per–**code point** category check via `isSuspiciousByCategory` (Cf, or Cc except TAB/LF/CR). **Optional third layer**: `extended: true` adds `extendedConfusableChars`; hits are **`severity: low`** and **`category: Extended blocklist`** unless already caught as core (**high** wins).
-2. **Unicode code points, not UTF-16 code units**: JavaScript strings are UTF-16. Supplementary characters (e.g. U+E0001, U+E0020–U+E007F tag letters, U+E0100+ variation selectors) occupy two code units. Scans **must** advance with `codePointAt` and `String.fromCodePoint` (or equivalent) so astral characters are evaluated as a single scalar value. Never rely on `charAt(i)` alone for security-sensitive classification.
-3. **Column numbers**: In detailed mode, `column` is **1-based** and is the **starting UTF-16 index** of the code point within that line plus one (aligned with common editor column semantics for JavaScript strings).
-4. **Snippets**: Findings use a prefix of the line (`substring(0, 80)`) for context; this is UTF-16-based length, not grapheme count.
-
-## Changing behavior
-
-- **New explicit characters**: update [`src/constants.js`](src/constants.js) if they are not already covered by Cf/Cc logic and you need them named or prioritized distinctly. Reserve this for **high-signal** scalars; document additions in [`README.md` Scope](README.md#scope).
-- **Extended blocklist** (opt-in, low severity): update [`src/extended-blocklist.js`](src/extended-blocklist.js) only for **ASCII-lookalike** or **high-signal invisible** scalars; update [`README.md` Scope](README.md#scope) when the boundary changes.
-- **Strict supplemental invisibles** on the core list (non-Cf/Cc): keep **minimal** — prefer Cf/Cc when Unicode classifies the code point that way.
-- **New Cf/Cc ranges** (Unicode adds blocks): update [`src/unicode-categories.js`](src/unicode-categories.js).
-- **Scanning logic**: only [`src/main.js`](src/main.js) unless you intentionally extend helpers elsewhere.
-
-Always run tests, lint, and build before merging (see [`DEVELOPMENT.md`](DEVELOPMENT.md)).
-
-## Security stance
-
-Treat findings as **high-signal alerts** for review, not as a complete proof of malice. Legitimate content can include format characters (e.g. in internationalized data); the tool’s job is to make them **visible** to automation and humans.
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/README.md
+++ b/README.md
@@ -332,3 +332,7 @@ Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing 
 # Author
 
 **anti-trojan-source** © [Liran Tal](https://github.com/lirantal), Released under the [Apache-2.0](./LICENSE) License.
+
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+# Release
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and release notes.
+
+## Release Flow
+
+1. Ensure all intended changes are merged and CI is green.
+2. Run `npm run version` to apply Changesets version and changelog updates.
+3. Review the generated package and changelog changes.
+4. Run the release command, if configured for the repository.
+
+No root `release` script is currently defined. Use the repository's publishing workflow or add one before publishing.
+
+## Changesets
+
+Add a changeset for user-facing package behavior changes:
+
+```sh
+npm run changeset
+```
+
+Documentation-only, test-only, and internal refactor PRs usually do not need a changeset unless they describe or accompany a release-worthy behavior change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# anti-trojan-source Documentation
+
+This directory contains project documentation for maintainers and coding agents.
+
+## Core Docs
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Root References
+
+- [Project README](../README.md) - user-facing overview, installation, and usage.
+- [Contributing](../CONTRIBUTING.md) - issue, PR, commit, and agent expectations.
+- [Release](../RELEASE.md) - Changesets and release workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+## Overview
+
+anti-trojan-source package description: Detect trojan source attacks that employ unicode bidi attacks to inject malicious code.
+
+## Repository Structure
+
+- `package.json` - root package scripts and dependency metadata.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,23 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm build` - builds the project.
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+- `pnpm format` - formats supported files.
+
+## Repository Notes
+
+This repository is organized around the root package `anti-trojan-source`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes repository context by refreshing `AGENTS.md` and adding a docs index with development, testing, architecture, and conventions for maintainers and coding agents. Adds `RELEASE.md` with Changesets guidance and links docs from `README.md`; no package behavior changes.

<sup>Written for commit 53c745d8ed36f36e4151b827f073a33ee83da357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/anti-trojan-source/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

